### PR TITLE
Fix import for datetime in RealtimeDBQueue

### DIFF
--- a/jobs/RealtimeDBQueue.py
+++ b/jobs/RealtimeDBQueue.py
@@ -1,6 +1,6 @@
 import time
-from datetime import timezone
-from firebase_admin import db, datetime
+from datetime import datetime, timezone
+from firebase_admin import db
 from firebase_admin.exceptions import FirebaseError
 
 class RealtimeDBQueue:
@@ -70,4 +70,4 @@ class RealtimeDBQueue:
             print(f"Task failed: {e}")
 
     def iso_now(self):
-        return datetime.datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/webserver/src/app/(authenticated)/page.tsx
+++ b/webserver/src/app/(authenticated)/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
 
         setLoading(true);
 
-        let events: CalendarEvent[] = [];
+        const events: CalendarEvent[] = [];
 
         try {
           const token = await user.getIdToken();

--- a/webserver/src/app/(authenticated)/page.tsx
+++ b/webserver/src/app/(authenticated)/page.tsx
@@ -56,20 +56,31 @@ export default function Page() {
 
         setLoading(true);
 
-        try {
-          const dbReference = dbRef(db());
-          const programmedLessonsRef = child(
-            dbReference,
-            `users/${user.uid}/programmedLessons`
-          );
-          const programmedLessonsSnapshot = await get(programmedLessonsRef);
+        let events: CalendarEvent[] = [];
 
-          if (programmedLessonsSnapshot.exists()) {
-            const programmedLessonsData = programmedLessonsSnapshot.val();
-            const markedDays = Object.values(programmedLessonsData).map(
-              (lesson: any) => new Date(lesson.date)
+        try {
+          const token = await user.getIdToken();
+          const response = await fetch(
+            `/api/users/${user.uid}/programmedLessons`,
+            {
+              headers: { Authorization: `Bearer ${token}` },
+            }
+          );
+
+          if (response.ok) {
+            const data = await response.json();
+            const markedDays = data.programmedLessons.map((l: any) =>
+              new Date(l.date)
             );
             setMarkedLearningDays(markedDays);
+            events.push(
+              ...markedDays.map((date: Date, idx: number) => ({
+                id: `programmed-${idx}`,
+                title: "Planned Learning",
+                date,
+                courseId: "",
+              }))
+            );
           }
         } catch (error) {
           console.error("Error fetching programmed lessons:", error);
@@ -166,8 +177,8 @@ export default function Page() {
           );
           const enrollmentsSnapshot = await get(enrollmentsRef);
 
-          if (enrollmentsSnapshot.exists()) {
-            const enrollments = enrollmentsSnapshot.val();
+            if (enrollmentsSnapshot.exists()) {
+              const enrollments = enrollmentsSnapshot.val();
 
             const enrolledCoursesPromises = Object.keys(enrollments).map(
               async (courseId) => {
@@ -241,7 +252,6 @@ export default function Page() {
             ).filter(Boolean) as Course[];
             setEnrolledCourses(resolvedCourses);
 
-            const events: CalendarEvent[] = [];
             resolvedCourses.forEach((course) => {
               if (!course) return;
 
@@ -257,10 +267,9 @@ export default function Page() {
                   courseId: course.id,
                 });
               }
-            });
-
+              });
+            }
             setCalendarEvents(events);
-          }
         } catch (error) {
           console.error("Error fetching enrolled courses:", error);
         }

--- a/webserver/src/app/(authenticated)/page.tsx
+++ b/webserver/src/app/(authenticated)/page.tsx
@@ -69,8 +69,8 @@ export default function Page() {
 
           if (response.ok) {
             const data = await response.json();
-            const markedDays = data.programmedLessons.map((l: any) =>
-              new Date(l.date)
+            const markedDays = data.programmedLessons.map(
+              (l: any) => new Date(l.date)
             );
             setMarkedLearningDays(markedDays);
             events.push(
@@ -177,8 +177,8 @@ export default function Page() {
           );
           const enrollmentsSnapshot = await get(enrollmentsRef);
 
-            if (enrollmentsSnapshot.exists()) {
-              const enrollments = enrollmentsSnapshot.val();
+          if (enrollmentsSnapshot.exists()) {
+            const enrollments = enrollmentsSnapshot.val();
 
             const enrolledCoursesPromises = Object.keys(enrollments).map(
               async (courseId) => {
@@ -267,9 +267,9 @@ export default function Page() {
                   courseId: course.id,
                 });
               }
-              });
-            }
-            setCalendarEvents(events);
+            });
+          }
+          setCalendarEvents(events);
         } catch (error) {
           console.error("Error fetching enrolled courses:", error);
         }


### PR DESCRIPTION
## Summary
- connect calendar with API so marked days are loaded from the server
- merge planned learning days with existing events

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684028e0d8f88328a70d89f8837caab5