### PR TITLE
Integrate invites and scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 jobs/.env
 jobs/.firebase-service-account.json
 jobs/__pycache__
+webserver/.yarnrc.yml
+webserver/node_modules

--- a/webserver/lib/context/InviteCountContext.tsx
+++ b/webserver/lib/context/InviteCountContext.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface InviteCountContextValue {
+  count: number;
+  refresh: () => void;
+}
+
+const InviteCountContext = createContext<InviteCountContextValue>({
+  count: 0,
+  refresh: () => {},
+});
+
+export function useInviteCount() {
+  return useContext(InviteCountContext);
+}
+
+export default InviteCountContext;

--- a/webserver/lib/models/course.ts
+++ b/webserver/lib/models/course.ts
@@ -1,7 +1,10 @@
 export default interface Course {
-    id: string;
-    ownerId: string;
-    name: string;
-    description?: string;
-    lessons?: string[];
+  id: string;
+  ownerId: string;
+  name: string;
+  description?: string;
+  lessons?: string[];
+  scheduledDate?: string;
+  recurrence?: "once" | "weekly";
+  status?: "UPCOMING" | "PAST";
 }

--- a/webserver/lib/models/course.ts
+++ b/webserver/lib/models/course.ts
@@ -7,4 +7,5 @@ export default interface Course {
   scheduledDate?: string;
   recurrence?: "once" | "weekly";
   status?: "UPCOMING" | "PAST";
+  access?: "open" | "invite";
 }

--- a/webserver/lib/models/coursePreview.ts
+++ b/webserver/lib/models/coursePreview.ts
@@ -1,7 +1,10 @@
 export default interface CoursePreview {
-    id: string;
-    ownerId: string;
-    name: string;
-    description?: string;
-    imageUrl?: string;
+  id: string;
+  ownerId: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  scheduledDate?: string;
+  recurrence?: "once" | "weekly";
+  status?: "UPCOMING" | "PAST";
 }

--- a/webserver/lib/models/coursePreview.ts
+++ b/webserver/lib/models/coursePreview.ts
@@ -7,4 +7,5 @@ export default interface CoursePreview {
   scheduledDate?: string;
   recurrence?: "once" | "weekly";
   status?: "UPCOMING" | "PAST";
+  access?: "open" | "invite";
 }

--- a/webserver/lib/navigation.ts
+++ b/webserver/lib/navigation.ts
@@ -4,6 +4,7 @@ export interface NavLink {
 }
 
 export const mainNavLinks: NavLink[] = [
-    { name: "Home", href: "/" },
-    { name: "Courses", href: "/courses" },
+  { name: "Home", href: "/" },
+  { name: "Courses", href: "/courses" },
+  { name: "Invites", href: "/invites" },
 ];

--- a/webserver/src/app/(authenticated)/courses/[courseId]/page.tsx
+++ b/webserver/src/app/(authenticated)/courses/[courseId]/page.tsx
@@ -34,13 +34,16 @@ export default async function Page({ params }:
     }) : [null]
 
     return (<>
-        <CourseDetails 
+        <CourseDetails
             course={{
                 id: courseId,
                 ownerId: course.ownerId,
                 name: course.name,
                 description: course.description,
                 lessons: course.lessons,
+                scheduledDate: course.scheduledDate,
+                recurrence: course.recurrence,
+                access: course.access,
             }}
             owner={{
                 displayName: await getOwnerDisplayName(course.ownerId),

--- a/webserver/src/app/(authenticated)/courses/[courseId]/page.tsx
+++ b/webserver/src/app/(authenticated)/courses/[courseId]/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = 'force-dynamic';
 import CourseDetails from "@/components/ui/CourseDetails";
 import { firebase } from "lib/firebaseServer"
 import Course from "lib/models/course";
@@ -36,10 +37,11 @@ export default async function Page({ params }:
         <CourseDetails 
             course={{
                 id: courseId,
+                ownerId: course.ownerId,
                 name: course.name,
                 description: course.description,
                 lessons: course.lessons,
-            }} 
+            }}
             owner={{
                 displayName: await getOwnerDisplayName(course.ownerId),
                 profilePicture: owner.photoURL

--- a/webserver/src/app/(authenticated)/courses/page.tsx
+++ b/webserver/src/app/(authenticated)/courses/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { ref as dbRef, child, get, query, orderByKey } from "firebase/database";
 import { ref as storageRef, getDownloadURL } from "firebase/storage";
-import { db, storage } from "lib/firebase";
+import { db, storage, auth } from "lib/firebase";
 import { useState, useEffect } from "react";
 import CourseCard from "@/components/ui/CourseCard";
 import CoursePreview from "lib/models/coursePreview";
@@ -12,8 +12,9 @@ export default function Page() {
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
     const [currentPage, setCurrentPage] = useState<number>(1);
-    const [totalPages, setTotalPages] = useState<number>(1);
     const [searchTerm, setSearchTerm] = useState<string>("");
+    const [filter, setFilter] = useState<"all" | "created" | "joined">("all");
+    const [enrollments, setEnrollments] = useState<Record<string, unknown>>({});
     const ITEMS_PER_PAGE = 8;
 
     const fetchCourses = async (page: number = 1) => {
@@ -21,12 +22,6 @@ export default function Page() {
         try {
             const dbReference = dbRef(db);
             
-            const totalCountSnapshot = await get(child(dbReference, "/courses"));
-            if (totalCountSnapshot.exists()) {
-                const totalCourses = Object.keys(totalCountSnapshot.val()).length;
-                const calculatedTotalPages = Math.ceil(totalCourses / ITEMS_PER_PAGE);
-                setTotalPages(calculatedTotalPages);
-            }
 
             const coursesQuery = query(
                 child(dbReference, "/courses"),
@@ -91,7 +86,6 @@ export default function Page() {
                 setCurrentPage(page);
             } else {
                 setCourseData([]);
-                setTotalPages(1);
             }
         } catch (error) {
             console.error(error);
@@ -101,19 +95,32 @@ export default function Page() {
         }
     };
 
+    const fetchEnrollments = async () => {
+        const user = auth.currentUser;
+        if (!user) return;
+        try {
+            const token = await user.getIdToken();
+            const res = await fetch('/api/enrollments', {
+                headers: { Authorization: `Bearer ${token}` }
+            });
+            if (res.ok) {
+                const data = await res.json();
+                setEnrollments(data.enrollments || {});
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
     useEffect(() => {
         fetchCourses();
+        fetchEnrollments();
     }, []);
 
     const handlePageChange = (page: number) => {
-        if (page >= 1 && page <= (searchTerm ? filteredTotalPages : totalPages) && page !== currentPage) {
-            if (searchTerm) {
-                setCurrentPage(page);
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            } else {
-                fetchCourses(page);
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            }
+        if (page >= 1 && page <= filteredTotalPages && page !== currentPage) {
+            setCurrentPage(page);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
         }
     };
 
@@ -124,37 +131,53 @@ export default function Page() {
     };
 
     const goToNextPage = () => {
-        if (currentPage < (searchTerm ? filteredTotalPages : totalPages)) {
+        if (currentPage < filteredTotalPages) {
             handlePageChange(currentPage + 1);
         }
     };
 
-    const filteredCourses = searchTerm
-        ? courseData.filter(course => 
-            course.name.toLowerCase().includes(searchTerm.toLowerCase()) || 
+    const searchFiltered = searchTerm
+        ? courseData.filter(course =>
+            course.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
             (course.description?.toLowerCase().includes(searchTerm.toLowerCase()) ?? false)
           )
         : courseData;
-    
-    const filteredTotalPages = searchTerm
-        ? Math.max(1, Math.ceil(filteredCourses.length / ITEMS_PER_PAGE))
-        : totalPages;
 
-    const paginatedCourses = searchTerm
-        ? filteredCourses.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE)
-        : filteredCourses;
+    const filteredCourses = searchFiltered.filter(course => {
+        const user = auth.currentUser;
+        if (filter === "created") {
+            return user && course.ownerId === user.uid;
+        }
+        if (filter === "joined") {
+            return enrollments[course.id] !== undefined;
+        }
+        return true;
+    });
+    
+    const filteredTotalPages = Math.max(1, Math.ceil(filteredCourses.length / ITEMS_PER_PAGE));
+
+    const paginatedCourses = filteredCourses.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
 
     useEffect(() => {
         setCurrentPage(1);
-    }, [searchTerm]);
+    }, [searchTerm, filter]);
 
     return (            
         <div className="flex flex-col">
-            <div className="w-full container flex mx-auto justify-center items-center">
+            <div className="w-full container flex mx-auto justify-center items-center gap-4">
                 <label className="input flex justify-center items-center md:max-w-150 w-full">
                     <svg className="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g strokeLinejoin="round" strokeLinecap="round" strokeWidth="2.5" fill="none" stroke="currentColor"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></g></svg>
                     <input type="search" className="grow" placeholder="Search courses..." value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
                 </label>
+                <select
+                    className="select select-bordered w-36"
+                    value={filter}
+                    onChange={(e) => setFilter(e.target.value as "all" | "created" | "joined")}
+                >
+                    <option value="all">All</option>
+                    <option value="created">Created</option>
+                    <option value="joined">Joined</option>
+                </select>
             </div>
             <div className="container mx-auto px-4 py-8 flex flex-col">
                 {error && (

--- a/webserver/src/app/(authenticated)/invites/page.tsx
+++ b/webserver/src/app/(authenticated)/invites/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import CourseCard from "@/components/ui/CourseCard";
+import Skeleton from "@/components/ui/Skeleton";
+import CoursePreview from "lib/models/coursePreview";
+import { auth } from "lib/firebase";
+import { useNotification } from "lib/context/NotificationContext";
+import { useInviteCount } from "lib/context/InviteCountContext";
+
+interface InviteCourse extends CoursePreview {
+  ownerId: string;
+}
+
+export default function Page() {
+  const [invites, setInvites] = useState<InviteCourse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { showNotification } = useNotification();
+  const { refresh } = useInviteCount();
+
+  const fetchInvites = async () => {
+    const user = auth().currentUser;
+    if (!user) return;
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/users/${user.uid}/invites`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setInvites(data.invites || []);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchInvites();
+  }, []);
+
+  const handleAccept = async (courseId: string) => {
+    const user = auth().currentUser;
+    if (!user) return;
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/users/${user.uid}/invites`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ courseId }),
+      });
+      if (res.ok) {
+        showNotification("Invitation accepted", "success");
+        setInvites((prev) => prev.filter((inv) => inv.id !== courseId));
+        refresh();
+      } else {
+        const e = await res.json();
+        showNotification(e.error || "Failed to accept", "error");
+      }
+    } catch (err) {
+      console.error(err);
+      showNotification("Failed to accept", "error");
+    }
+  };
+
+  const handleDecline = async (courseId: string) => {
+    const user = auth().currentUser;
+    if (!user) return;
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch(`/api/users/${user.uid}/invites`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ courseId }),
+      });
+      if (res.ok) {
+        showNotification("Invitation declined", "success");
+        setInvites((prev) => prev.filter((inv) => inv.id !== courseId));
+        refresh();
+      } else {
+        const e = await res.json();
+        showNotification(e.error || "Failed to decline", "error");
+      }
+    } catch (err) {
+      console.error(err);
+      showNotification("Failed to decline", "error");
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="text-2xl font-semibold mb-4">Course Invitations</h1>
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array(3)
+            .fill(0)
+            .map((_, i) => (
+              <div
+                key={`skeleton-${i}`}
+                className="flex flex-col rounded-lg border border-neutral-100 bg-white shadow-sm h-[340px]"
+              >
+                <Skeleton className="h-48 w-full rounded-t-lg" />
+                <div className="p-4">
+                  <Skeleton className="h-6 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-1/2 mb-3" />
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-9 w-full mt-4" />
+                </div>
+              </div>
+            ))}
+        </div>
+      ) : invites.length === 0 ? (
+        <p>No pending invitations.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {invites.map((inv) => (
+            <div key={inv.id} className="card bg-base-100 shadow">
+              <CourseCard course={inv} />
+              <div className="card-actions p-4 justify-end">
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={() => handleAccept(inv.id!)}
+                >
+                  Accept
+                </button>
+                <button
+                  className="btn btn-outline btn-sm"
+                  onClick={() => handleDecline(inv.id!)}
+                >
+                  Decline
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webserver/src/app/(authenticated)/invites/page.tsx
+++ b/webserver/src/app/(authenticated)/invites/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
   const { refresh } = useInviteCount();
 
   const fetchInvites = async () => {
-    const user = auth().currentUser;
+    const user = auth.currentUser;
     if (!user) return;
     try {
       const token = await user.getIdToken();
@@ -42,7 +42,7 @@ export default function Page() {
   }, []);
 
   const handleAccept = async (courseId: string) => {
-    const user = auth().currentUser;
+    const user = auth.currentUser;
     if (!user) return;
     try {
       const token = await user.getIdToken();
@@ -69,7 +69,7 @@ export default function Page() {
   };
 
   const handleDecline = async (courseId: string) => {
-    const user = auth().currentUser;
+    const user = auth.currentUser;
     if (!user) return;
     try {
       const token = await user.getIdToken();

--- a/webserver/src/app/(authenticated)/layout.tsx
+++ b/webserver/src/app/(authenticated)/layout.tsx
@@ -10,7 +10,8 @@ import CreateCourseForm from "@/components/ui/CreateCourseForm";
 import React, { createContext, useEffect, useState } from "react";
 import { get, ref } from "firebase/database";
 import { auth, db } from "lib/firebase";
-import { useRouter } from 'next/navigation';
+import { useRouter } from "next/navigation";
+import InviteCountContext from "lib/context/InviteCountContext";
 
 interface UserData {
   fullName: string;
@@ -30,25 +31,48 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
   useRequireEmailVerified();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
   const [userData, setUserData] = useState<UserData | null>(null);
+  const [inviteCount, setInviteCount] = useState<number>(0);
   const router = useRouter();
 
   useEffect(() => {
   }, [userData?.profilePicture]);
 
+  const fetchInviteCount = async (uid: string) => {
+    try {
+      const invitesRef = ref(db, `users/${uid}/invitedCourses`);
+      const snap = await get(invitesRef);
+      const count = snap.exists() ? Object.keys(snap.val()).length : 0;
+      setInviteCount(count);
+    } catch (error) {
+      console.error("Error loading invites count", error);
+    }
+  };
+
+  const refreshInvites = async () => {
+    const user = auth.currentUser;
+    if (user) {
+      await fetchInviteCount(user.uid);
+    }
+  };
   useEffect(() => {
     const unsubscribe = auth.onIdTokenChanged(async (user) => {
       if (user) {
         const userRef = ref(db, `users/${user.uid}`);
         const snapshot = await get(userRef);
         setUserData(snapshot.val() ? { ...snapshot.val() } : null);
+        await fetchInviteCount(user.uid);
+      } else {
+        setUserData(null);
+        setInviteCount(0);
       }
     });
     return unsubscribe;
   }, []);
 
   return (
-    <UserContext.Provider value={userData}>
-      <div className="w-full h-full box-border">
+    <InviteCountContext.Provider value={{ count: inviteCount, refresh: refreshInvites }}>
+      <UserContext.Provider value={userData}>
+        <div className="w-full h-full box-border">
         <nav className="fixed top-0 left-0 w-full z-50 navbar bg-base-100 shadow px-6">
           <div className="navbar-start">
             <Link href="/" className="flex items-center gap-2">
@@ -112,7 +136,7 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
               <PlusCircle size={16} className="mr-1" />
               Create Course
             </button>
-            <button className="btn btn-ghost btn-circle">
+            <Link href="/invites" className="btn btn-ghost btn-circle">
               <div className="indicator">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -128,9 +152,13 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
                     d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
                   />
                 </svg>
-                <span className="badge badge-xs badge-primary indicator-item"></span>
+                {inviteCount > 0 && (
+                  <span className="badge badge-xs badge-primary indicator-item">
+                    {inviteCount}
+                  </span>
+                )}
               </div>
-            </button>
+            </Link>
             <Link href="/profile" className="no-underline">
               <div className="flex flex-row justify-center items-center gap-2 cursor-pointer">
                 <div className="avatar">
@@ -181,6 +209,7 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
           />
         </Modal>
       </div>
-    </UserContext.Provider>
+      </UserContext.Provider>
+    </InviteCountContext.Provider>
   );
 }

--- a/webserver/src/app/(authenticated)/page.tsx
+++ b/webserver/src/app/(authenticated)/page.tsx
@@ -201,23 +201,26 @@ export default function Page() {
             setEnrolledCourses(resolvedCourses);
             
             const events: CalendarEvent[] = [];
-            resolvedCourses.forEach(course => {
-              if (!course) return;
-              
-              const today = new Date(2025, 3, 6);
-              for (let i = 0; i < 3; i++) {
-                const date = new Date(today);
-                date.setDate(date.getDate() + Math.floor(Math.random() * 30));
-                
+            resolvedCourses.forEach((course) => {
+              if (!course || !course.scheduledDate) return;
+
+              const firstDate = new Date(course.scheduledDate);
+              const occurrences = course.recurrence === 'weekly' ? 4 : 1;
+              for (let i = 0; i < occurrences; i++) {
+                const date = new Date(firstDate);
+                if (course.recurrence === 'weekly') {
+                  date.setDate(firstDate.getDate() + i * 7);
+                }
+
                 events.push({
                   id: `${course.id}-${i}`,
                   title: course.title || 'Untitled Course',
-                  date: date,
-                  courseId: course.id
+                  date,
+                  courseId: course.id,
+                  status: date < new Date() ? 'PAST' : 'UPCOMING',
                 });
               }
             });
-            
             setCalendarEvents(events);
           }
         } catch (error) {

--- a/webserver/src/app/(authenticated)/page.tsx
+++ b/webserver/src/app/(authenticated)/page.tsx
@@ -37,7 +37,6 @@ export default function Page() {
   const [enrolledCourses, setEnrolledCourses] = useState<Course[]>([]);
   const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [markedLearningDays, setMarkedLearningDays] = useState<Date[]>([]);
   const router = useRouter();
   const { showNotification } = useNotification();
 
@@ -49,21 +48,7 @@ export default function Page() {
 
         setLoading(true);
         
-        try {
-          const dbReference = dbRef(db);
-          const programmedLessonsRef = child(dbReference, `users/${user.uid}/programmedLessons`);
-          const programmedLessonsSnapshot = await get(programmedLessonsRef);
-          
-          if (programmedLessonsSnapshot.exists()) {
-            const programmedLessonsData = programmedLessonsSnapshot.val();
-            const markedDays = Object.values(programmedLessonsData).map(
-              (lesson: any) => new Date(lesson.date)
-            );
-            setMarkedLearningDays(markedDays);
-          }
-        } catch (error) {
-          console.error('Error fetching programmed lessons:', error);
-        }
+
 
         try {
           const dbReference = dbRef(db);
@@ -236,76 +221,6 @@ export default function Page() {
     fetchData();
   }, []);
 
-  const handleMarkDay = async (date: Date, isMarked: boolean) => {
-    try {
-      const user = auth.currentUser;
-      if (!user) {
-        showNotification("You must be logged in to mark days", "error");
-        return;
-      }
-
-      if (isMarked) {
-        setMarkedLearningDays(prev => [...prev, date]);
-      } else {
-        setMarkedLearningDays(prev => 
-          prev.filter(d => 
-            !(d.getDate() === date.getDate() && 
-              d.getMonth() === date.getMonth() && 
-              d.getFullYear() === date.getFullYear())
-          )
-        );
-      }
-      
-      const token = await user.getIdToken();
-      
-      const response = await fetch(`/api/users/${user.uid}/programmedLessons`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({
-          date: date.toISOString(),
-          isMarked
-        })
-      });
-      
-      if (response.ok) {
-        showNotification(
-          isMarked 
-            ? `Marked ${date.toLocaleDateString()} for learning` 
-            : `Unmarked ${date.toLocaleDateString()}`, 
-          "success"
-        );
-      } else {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to update learning schedule');
-      }
-    } catch (error) {
-      console.error('Error updating programmed lesson:', error);
-      showNotification("Failed to update your learning schedule", "error");
-      
-      setMarkedLearningDays(prev => {
-        const dateExists = prev.some(d => 
-          d.getDate() === date.getDate() && 
-          d.getMonth() === date.getMonth() && 
-          d.getFullYear() === date.getFullYear()
-        );
-        
-        if (isMarked && dateExists) {
-          return prev.filter(d => 
-            !(d.getDate() === date.getDate() && 
-              d.getMonth() === date.getMonth() && 
-              d.getFullYear() === date.getFullYear())
-          );
-        } else if (!isMarked && !dateExists) {
-          return [...prev, date];
-        }
-        
-        return prev;
-      });
-    }
-  };
 
   return (
     <div className="py-8 px-4 max-w-7xl mx-auto">
@@ -392,9 +307,7 @@ export default function Page() {
               
               <Calendar
                 events={calendarEvents}
-                markedDays={markedLearningDays}
                 onEventClick={(event) => router.push(`/courses/${event.courseId}`)}
-                onMarkDay={handleMarkDay}
               />
               
               <div className="divider"></div>
@@ -402,13 +315,8 @@ export default function Page() {
               <div className="mt-2 space-y-4">
                 <h3 className="font-semibold text-lg">Upcoming Lessons</h3>
                 
-                {[...calendarEvents, ...markedLearningDays.map((date, index) => ({
-                  id: `marked-${index}`,
-                  title: "Planned Learning",
-                  date,
-                  courseId: ""
-                }))]
-                  .filter(event => new Date(event.date) >= new Date(2025, 3, 6))
+                {calendarEvents
+                  .filter(event => new Date(event.date) >= new Date())
                   .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
                   .slice(0, 3)
                   .map(event => (
@@ -436,7 +344,7 @@ export default function Page() {
                     </div>
                   ))}
                   
-                {calendarEvents.length === 0 && markedLearningDays.length === 0 && (
+                {calendarEvents.length === 0 && (
                   <div className="text-center py-4 text-base-content/70">
                     No upcoming lessons scheduled
                   </div>

--- a/webserver/src/app/api/courses/[courseId]/invite/route.ts
+++ b/webserver/src/app/api/courses/[courseId]/invite/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "firebase-admin/auth";
+import { getDatabase } from "firebase-admin/database";
+import { firebase } from "lib/firebaseServer";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { courseId } = await params;
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Unauthorized: Missing or invalid token" },
+      { status: 401 }
+    );
+  }
+  const token = authHeader.split("Bearer ")[1];
+
+  try {
+    const decodedToken = await auth.verifyIdToken(token);
+    const requesterId = decodedToken.uid;
+
+    const courseRef = db.ref(`/courses/${courseId}`);
+    const courseSnapshot = await courseRef.get();
+    if (!courseSnapshot.exists()) {
+      return NextResponse.json({ error: "Course not found" }, { status: 404 });
+    }
+
+    const courseData = courseSnapshot.val();
+    if (courseData.ownerId !== requesterId) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    const { userId } = await req.json();
+    if (!userId) {
+      return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    updates[`/courses/${courseId}/invitedUsers/${userId}`] = true;
+    updates[`/users/${userId}/invitedCourses/${courseId}`] = true;
+    await db.ref().update(updates);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error inviting user:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/webserver/src/app/api/courses/[courseId]/participants/route.ts
+++ b/webserver/src/app/api/courses/[courseId]/participants/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "firebase-admin/auth";
+import { getDatabase } from "firebase-admin/database";
+import { firebase } from "lib/firebaseServer";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { courseId } = await params;
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Unauthorized: Missing or invalid token" },
+      { status: 401 }
+    );
+  }
+  const token = authHeader.split("Bearer ")[1];
+
+  try {
+    const decoded = await auth.verifyIdToken(token);
+    const userId = decoded.uid;
+
+    const courseRef = db.ref(`/courses/${courseId}`);
+    const courseSnapshot = await courseRef.get();
+    if (!courseSnapshot.exists()) {
+      return NextResponse.json({ error: "Course not found" }, { status: 404 });
+    }
+
+    const courseData = courseSnapshot.val();
+    if (courseData.ownerId !== userId && !courseData.invitedUsers?.[userId]) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    const usersRef = db.ref("/users");
+    const usersSnapshot = await usersRef.get();
+    if (!usersSnapshot.exists()) {
+      return NextResponse.json({ success: true, participants: [] });
+    }
+    const usersData = usersSnapshot.val();
+    const participants: Array<{
+      id: string;
+      fullName: string;
+      profilePicture: string;
+    }> = [];
+
+    for (const uid of Object.keys(usersData)) {
+      const userData = usersData[uid];
+      if (userData.enrollments && userData.enrollments[courseId]) {
+        participants.push({
+          id: uid,
+          fullName: userData.fullName || "",
+          profilePicture: userData.profilePicture || "",
+        });
+      }
+    }
+
+    if (!participants.find((p) => p.id === courseData.ownerId)) {
+      const owner = usersData[courseData.ownerId];
+      if (owner) {
+        participants.unshift({
+          id: courseData.ownerId,
+          fullName: owner.fullName || "",
+          profilePicture: owner.profilePicture || "",
+        });
+      }
+    }
+
+    return NextResponse.json({ success: true, participants });
+  } catch (error) {
+    console.error("Error fetching participants:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/webserver/src/app/api/courses/[courseId]/route.ts
+++ b/webserver/src/app/api/courses/[courseId]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuth } from 'firebase-admin/auth';
+import { getDatabase } from 'firebase-admin/database';
+import { firebase } from 'lib/firebaseServer';
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { courseId } = await params;
+  const authHeader = req.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json(
+      { error: 'Unauthorized: Missing or invalid token' },
+      { status: 401 }
+    );
+  }
+  const token = authHeader.split('Bearer ')[1];
+
+  try {
+    const decoded = await auth.verifyIdToken(token);
+    const userId = decoded.uid;
+
+    const courseRef = db.ref(`/courses/${courseId}`);
+    const courseSnapshot = await courseRef.get();
+    if (!courseSnapshot.exists()) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 });
+    }
+    const courseData = courseSnapshot.val();
+    if (courseData.ownerId !== userId) {
+      return NextResponse.json({ error: 'Permission denied' }, { status: 403 });
+    }
+
+    const { access } = await req.json();
+    if (!access || !['open', 'invite'].includes(access)) {
+      return NextResponse.json({ error: 'Invalid access value' }, { status: 400 });
+    }
+
+    await courseRef.update({ access });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error updating course:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/webserver/src/app/api/courses/route.ts
+++ b/webserver/src/app/api/courses/route.ts
@@ -16,11 +16,13 @@ async function parseFormData(req: NextRequest) {
   const name = formData.get('name') as string;
   const description = formData.get('description') as string;
   const imageFile = formData.get('image') as File | null;
+  const startDate = formData.get('startDate') as string;
+  const recurrence = (formData.get('recurrence') as string) || 'once';
 
   const buffer = imageFile ? Buffer.from(await imageFile.arrayBuffer()) : null;
 
   return {
-    fields: { name, description },
+    fields: { name, description, startDate, recurrence },
     file: buffer
       ? { buffer, originalName: imageFile?.name, mime: imageFile?.type }
       : null,
@@ -60,6 +62,13 @@ export async function POST(req: NextRequest) {
     if (!fields.name) {
       return NextResponse.json({ error: 'Course name is required' }, { status: 400 });
     }
+    if (!fields.startDate) {
+      return NextResponse.json({ error: 'Start date is required' }, { status: 400 });
+    }
+    const parsedDate = new Date(fields.startDate);
+    if (isNaN(parsedDate.getTime()) || parsedDate <= new Date()) {
+      return NextResponse.json({ error: 'Start date must be in the future' }, { status: 400 });
+    }
 
     const courseId = uuidv4();
 
@@ -75,6 +84,9 @@ export async function POST(req: NextRequest) {
       name: fields.name,
       description: fields.description || '',
       ownerId: userId,
+      scheduledDate: fields.startDate || '',
+      recurrence: fields.recurrence || 'once',
+      status: 'UPCOMING',
       createdAt: new Date().toISOString(),
     });
 

--- a/webserver/src/app/api/courses/route.ts
+++ b/webserver/src/app/api/courses/route.ts
@@ -18,11 +18,12 @@ async function parseFormData(req: NextRequest) {
   const imageFile = formData.get('image') as File | null;
   const startDate = formData.get('startDate') as string;
   const recurrence = (formData.get('recurrence') as string) || 'once';
+  const access = (formData.get('access') as string) || 'open';
 
   const buffer = imageFile ? Buffer.from(await imageFile.arrayBuffer()) : null;
 
   return {
-    fields: { name, description, startDate, recurrence },
+    fields: { name, description, startDate, recurrence, access },
     file: buffer
       ? { buffer, originalName: imageFile?.name, mime: imageFile?.type }
       : null,
@@ -86,6 +87,7 @@ export async function POST(req: NextRequest) {
       ownerId: userId,
       scheduledDate: fields.startDate || '',
       recurrence: fields.recurrence || 'once',
+      access: fields.access || 'open',
       status: 'UPCOMING',
       createdAt: new Date().toISOString(),
     });

--- a/webserver/src/app/api/enrollments/route.ts
+++ b/webserver/src/app/api/enrollments/route.ts
@@ -28,11 +28,19 @@ export async function POST(req: NextRequest) {
     
     const courseRef = db.ref(`/courses/${courseId}`);
     const courseSnapshot = await courseRef.get();
-    
+
     if (!courseSnapshot.exists()) {
       return NextResponse.json({ error: 'Course not found' }, { status: 404 });
     }
-    
+    const courseData = courseSnapshot.val();
+    if (
+      courseData.ownerId !== userId &&
+      courseData.access !== 'open' &&
+      !courseData.invitedUsers?.[userId]
+    ) {
+      return NextResponse.json({ error: 'Not invited to this course' }, { status: 403 });
+    }
+
     const enrollmentData = {
       courseId,
       enrolledAt: new Date().toISOString(),

--- a/webserver/src/app/api/users/[userId]/invites/route.ts
+++ b/webserver/src/app/api/users/[userId]/invites/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuth } from "firebase-admin/auth";
+import { getDatabase } from "firebase-admin/database";
+import { firebase } from "lib/firebaseServer";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { userId } = await params;
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Unauthorized: Missing or invalid token" },
+      { status: 401 }
+    );
+  }
+
+  const token = authHeader.split("Bearer ")[1];
+
+  try {
+    const decodedToken = await auth.verifyIdToken(token);
+    if (decodedToken.uid !== userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const invitesRef = db.ref(`/users/${userId}/invitedCourses`);
+    const invitesSnapshot = await invitesRef.get();
+
+    if (!invitesSnapshot.exists()) {
+      return NextResponse.json({ success: true, invites: [] });
+    }
+
+    const courseIds = Object.keys(invitesSnapshot.val());
+    const coursesRef = db.ref(`/courses`);
+    const coursesSnapshot = await coursesRef.get();
+    const coursesData = coursesSnapshot.exists() ? coursesSnapshot.val() : {};
+
+    const invites = courseIds
+      .map((id) => {
+        const course = coursesData[id];
+        if (!course) return null;
+        return { id, ...(course as object) };
+      })
+      .filter(Boolean);
+
+    return NextResponse.json({ success: true, invites });
+  } catch (error) {
+    console.error("Error fetching invites:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { userId } = await params;
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Unauthorized: Missing or invalid token" },
+      { status: 401 }
+    );
+  }
+
+  const token = authHeader.split("Bearer ")[1];
+
+  try {
+    const decodedToken = await auth.verifyIdToken(token);
+    if (decodedToken.uid !== userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const { courseId } = await req.json();
+    if (!courseId) {
+      return NextResponse.json({ error: "Missing courseId" }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    updates[`/users/${userId}/invitedCourses/${courseId}`] = null;
+    updates[`/courses/${courseId}/invitedUsers/${userId}`] = null;
+    updates[`/users/${userId}/enrollments/${courseId}`] = {
+      courseId,
+      enrolledAt: new Date().toISOString(),
+      status: "active",
+    };
+
+    await db.ref().update(updates);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error accepting invite:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const firebaseApp = firebase();
+  const auth = getAuth(firebaseApp);
+  const db = getDatabase(firebaseApp);
+
+  const { userId } = await params;
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Unauthorized: Missing or invalid token" },
+      { status: 401 }
+    );
+  }
+
+  const token = authHeader.split("Bearer ")[1];
+
+  try {
+    const decodedToken = await auth.verifyIdToken(token);
+    if (decodedToken.uid !== userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const { courseId } = await req.json();
+    if (!courseId) {
+      return NextResponse.json({ error: "Missing courseId" }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    updates[`/users/${userId}/invitedCourses/${courseId}`] = null;
+    updates[`/courses/${courseId}/invitedUsers/${userId}`] = null;
+
+    await db.ref().update(updates);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error declining invite:", error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/webserver/src/app/api/users/route.ts
+++ b/webserver/src/app/api/users/route.ts
@@ -84,6 +84,19 @@ export async function GET(req: NextRequest) {
     
     const url = new URL(req.url);
     const queryUserId = url.searchParams.get('userId');
+    const searchQuery = url.searchParams.get('search');
+
+    if (searchQuery) {
+      const list = await auth.listUsers();
+      const matched = list.users.filter(u =>
+        u.email?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        u.displayName?.toLowerCase().includes(searchQuery.toLowerCase())
+      ).slice(0, 10);
+      return NextResponse.json({
+        success: true,
+        users: matched.map(u => ({ id: u.uid, email: u.email, name: u.displayName }))
+      });
+    }
     
     if (queryUserId) {
       const userRef = db.ref(`/users/${queryUserId}`);

--- a/webserver/src/components/ui/Calendar.tsx
+++ b/webserver/src/components/ui/Calendar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect } from 'react';
-import { ChevronLeft, ChevronRight, Plus, Check } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import cn from 'lib/utils/cn';
 
-type CalendarEvent = {
+export type CalendarEvent = {
   id: string;
   title: string;
   date: Date;
@@ -14,61 +14,23 @@ type CalendarEvent = {
 interface CalendarProps {
   events: CalendarEvent[];
   onEventClick?: (event: CalendarEvent) => void;
-  onMarkDay?: (date: Date, isMarked: boolean) => void;
-  markedDays?: Date[];
 }
 
-export function Calendar({ events, onEventClick, onMarkDay, markedDays = [] }: CalendarProps) {
+export function Calendar({ events, onEventClick }: CalendarProps) {
   const [currentMonth, setCurrentMonth] = useState(new Date());
-  const [localMarkedDays, setLocalMarkedDays] = useState<Set<string>>(new Set());
-  const [isMarkingMode, setIsMarkingMode] = useState(false);
-  
-  useEffect(() => {
-    const markedDaysSet = new Set<string>();
-    markedDays.forEach(date => {
-      markedDaysSet.add(getDateKey(date));
-    });
-    setLocalMarkedDays(markedDaysSet);
-  }, [markedDays]);
-  
-  const getDateKey = (date: Date) => {
-    return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-  };
-  
-  const toggleMarkDay = (day: number) => {
-    if (!isMarkingMode) return;
-    
-    const date = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day);
-    const dateKey = getDateKey(date);
-    
-    const newMarkedDays = new Set(localMarkedDays);
-    const isCurrentlyMarked = newMarkedDays.has(dateKey);
-    
-    if (isCurrentlyMarked) {
-      newMarkedDays.delete(dateKey);
-    } else {
-      newMarkedDays.add(dateKey);
-    }
-    
-    setLocalMarkedDays(newMarkedDays);
-    
-    if (onMarkDay) {
-      onMarkDay(date, !isCurrentlyMarked);
-    }
-  };
-  
+
   const daysInMonth = new Date(
     currentMonth.getFullYear(),
     currentMonth.getMonth() + 1,
     0
   ).getDate();
-  
+
   const firstDayOfMonth = new Date(
     currentMonth.getFullYear(),
     currentMonth.getMonth(),
     1
   ).getDay();
-  
+
   const getEventsForDay = (day: number) => {
     const date = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day);
     return events.filter(event => {
@@ -80,69 +42,42 @@ export function Calendar({ events, onEventClick, onMarkDay, markedDays = [] }: C
       );
     });
   };
-  
-  const isDayMarked = (day: number) => {
-    const date = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day);
-    return localMarkedDays.has(getDateKey(date));
-  };
-  
+
   const prevMonth = () => {
     setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1));
   };
-  
+
   const nextMonth = () => {
     setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1));
   };
-  
+
   const monthYear = currentMonth.toLocaleDateString('en-US', {
     month: 'long',
     year: 'numeric',
   });
-  
+
   return (
     <div className="w-full">
       <div className="flex justify-between items-center mb-4">
-        <button 
-          onClick={prevMonth} 
+        <button
+          onClick={prevMonth}
           className="btn btn-sm btn-ghost btn-circle"
           aria-label="Previous month"
         >
           <ChevronLeft size={20} />
         </button>
-        
+
         <h3 className="font-bold text-lg">{monthYear}</h3>
-        
-        <button 
-          onClick={nextMonth} 
+
+        <button
+          onClick={nextMonth}
           className="btn btn-sm btn-ghost btn-circle"
           aria-label="Next month"
         >
           <ChevronRight size={20} />
         </button>
       </div>
-      
-      <div className="flex justify-end mb-2">
-        <button 
-          className={cn(
-            "btn btn-sm gap-2",
-            isMarkingMode ? "btn-primary" : "btn-outline btn-primary"
-          )}
-          onClick={() => setIsMarkingMode(!isMarkingMode)}
-        >
-          {isMarkingMode ? (
-            <>
-              <Check size={16} />
-              <span>Done Marking</span>
-            </>
-          ) : (
-            <>
-              <Plus size={16} />
-              <span>Mark Days for Learning</span>
-            </>
-          )}
-        </button>
-      </div>
-      
+
       <div className="min-h-[400px]">
         <div className="grid grid-cols-7 text-center mb-2">
           {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
@@ -151,77 +86,56 @@ export function Calendar({ events, onEventClick, onMarkDay, markedDays = [] }: C
             </div>
           ))}
         </div>
-        
-        <div className={cn(
-          "grid grid-cols-7 gap-1",
-          isMarkingMode && "cursor-pointer"
-        )}>
+
+        <div className="grid grid-cols-7 gap-1">
           {Array.from({ length: firstDayOfMonth }).map((_, index) => (
             <div key={`empty-${index}`} className="aspect-square p-1"></div>
           ))}
-          
+
           {Array.from({ length: daysInMonth }).map((_, index) => {
             const day = index + 1;
             const dayEvents = getEventsForDay(day);
             const hasEvents = dayEvents.length > 0;
-            const isMarked = isDayMarked(day);
-            const isToday = new Date().getDate() === day && 
-                            new Date().getMonth() === currentMonth.getMonth() && 
+            const isToday = new Date().getDate() === day &&
+                            new Date().getMonth() === currentMonth.getMonth() &&
                             new Date().getFullYear() === currentMonth.getFullYear();
-            
+
             return (
-              <div 
-                key={day} 
-                className={cn(
-                  "aspect-square p-1 relative",
-                  (hasEvents || isMarkingMode) && "cursor-pointer",
-                  isMarkingMode && "hover:opacity-80"
-                )}
-                onClick={() => isMarkingMode ? toggleMarkDay(day) : null}
+              <div
+                key={day}
+                className={cn("aspect-square p-1 relative", hasEvents && "cursor-pointer")}
+                onClick={() => {
+                  if (hasEvents && onEventClick) {
+                    onEventClick(dayEvents[0]);
+                  }
+                }}
               >
-                <div 
+                <div
                   className={cn(
                     "h-full w-full flex flex-col justify-start items-center rounded-md p-1",
                     isToday && "border-2 border-primary",
-                    hasEvents && "bg-base-200 hover:bg-base-300",
-                    isMarked && "bg-success/20 hover:bg-success/30",
-                    isMarked && isToday && "border-success"
+                    hasEvents && "bg-base-200 hover:bg-base-300"
                   )}
                 >
                   <div className="relative w-full flex justify-center">
-                    <span className={cn(
-                      "text-sm font-medium",
-                      isToday && "text-primary",
-                      isMarked && "text-success"
-                    )}>
-                      {day}
-                    </span>
-                    
-                    {isMarked && (
-                      <div className="absolute right-0 top-0">
-                        <Check size={12} className="text-success" />
-                      </div>
-                    )}
+                    <span className={cn("text-sm font-medium", isToday && "text-primary")}>{day}</span>
                   </div>
-                  
-                  {hasEvents && !isMarkingMode && (
+
+                  {hasEvents && (
                     <div className="mt-1 w-full">
                       {dayEvents.slice(0, 2).map((event) => (
-                        <div 
+                        <div
                           key={event.id}
                           className="bg-primary/20 text-primary text-xs mb-1 truncate rounded px-1"
                           onClick={(e) => {
                             e.stopPropagation();
-                            if (onEventClick) {
-                              onEventClick(event);
-                            }
-                          }}                          
+                            onEventClick?.(event);
+                          }}
                         >
                           {event.title.substring(0, 8)}
                           {event.title.length > 8 && '...'}
                         </div>
                       ))}
-                      
                       {dayEvents.length > 2 && (
                         <div className="text-xs text-base-content/70 text-center">
                           +{dayEvents.length - 2} more
@@ -233,14 +147,6 @@ export function Calendar({ events, onEventClick, onMarkDay, markedDays = [] }: C
               </div>
             );
           })}
-        </div>
-
-        <div
-            className={`mt-4 text-sm text-base-content/70 bg-base-200 p-3 rounded-md text-center transition-opacity duration-200 ${
-                isMarkingMode ? "opacity-100" : "opacity-0 pointer-events-none"
-            }`}
-            >
-            Click on days to mark them as learning days. Click again to unmark.
         </div>
       </div>
     </div>

--- a/webserver/src/components/ui/CourseCard.tsx
+++ b/webserver/src/components/ui/CourseCard.tsx
@@ -127,10 +127,12 @@ export default function CourseCard({
                 {loading ? (
                     <div className="w-10 h-10 bg-gray-300 rounded-full animate-pulse" />
                 ) : displayProfilePicture ? (
-                    <img
+                    <Image
                     src={`${displayProfilePicture}?t=${new Date().getTime()}`}
                     alt=""
-                    className="w-full h-full object-cover"
+                    fill
+                    sizes="40px"
+                    className="object-cover"
                     />
                 ) : (
                     <div className="bg-neutral-focus text-neutral-content rounded-full w-10 h-10 flex items-center justify-center">

--- a/webserver/src/components/ui/CourseDetails.tsx
+++ b/webserver/src/components/ui/CourseDetails.tsx
@@ -5,7 +5,8 @@ import CourseDiscussion from "./CourseDiscussion";
 import { Calendar, Heart, Share2 } from "lucide-react";
 import { useNotification } from "lib/context/NotificationContext";
 import { useState, useEffect } from "react";
-import { auth } from "lib/firebase";
+import { auth, db } from "lib/firebase";
+import { ref, get } from "firebase/database";
 import Modal from "./Modal";
 import { useRouter } from "next/navigation";
 
@@ -33,6 +34,72 @@ export default function CourseDetails({
   const [isEnrolled, setIsEnrolled] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isCheckingEnrollment, setIsCheckingEnrollment] = useState(true);
+  const [hasAccess, setHasAccess] = useState<boolean | null>(null);
+  const [isOwner, setIsOwner] = useState(false);
+  const [inviteId, setInviteId] = useState("");
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [participants, setParticipants] = useState<{
+    id: string;
+    fullName: string;
+    profilePicture: string;
+  }[]>([]);
+  const [participantsLoading, setParticipantsLoading] = useState(true);
+
+  const fetchParticipants = async () => {
+    setParticipantsLoading(true);
+    try {
+      const token = await auth.currentUser?.getIdToken();
+      if (!token) return;
+      const response = await fetch(`/api/courses/${course.id}/participants`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setParticipants(data.participants || []);
+      }
+    } catch (error) {
+      console.error("Error loading participants:", error);
+    } finally {
+      setParticipantsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchParticipants();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [course.id]);
+
+  useEffect(() => {
+    const verifyAccess = async () => {
+      const user = auth.currentUser;
+      if (!user) {
+        setHasAccess(false);
+        router.push("/courses");
+        return;
+      }
+      if (user.uid === course.ownerId) {
+        setHasAccess(true);
+        setIsOwner(true);
+        return;
+      }
+
+      try {
+        const invitationRef = ref(db, `/courses/${course.id}/invitedUsers/${user.uid}`);
+        const snapshot = await get(invitationRef);
+        if (snapshot.exists()) {
+          setHasAccess(true);
+        } else {
+          setHasAccess(false);
+          router.push("/courses");
+        }
+      } catch {
+        setHasAccess(false);
+        router.push("/courses");
+      }
+    };
+
+    verifyAccess();
+  }, [course.id, course.ownerId, router]);
 
   useEffect(() => {
     const checkEnrollmentStatus = async () => {
@@ -178,6 +245,45 @@ export default function CourseDetails({
       setIsLoading(false);
     }
   };
+
+  const handleInvite = async () => {
+    if (!inviteId.trim()) return;
+    try {
+      setInviteLoading(true);
+      const token = await auth.currentUser?.getIdToken();
+      const response = await fetch(`/api/courses/${course.id}/invite`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ userId: inviteId.trim() }),
+      });
+      if (response.ok) {
+        showNotification("User invited", "success");
+        setInviteId("");
+        fetchParticipants();
+      } else {
+        const err = await response.json();
+        showNotification(err.error || "Failed to invite", "error");
+      }
+    } catch {
+      showNotification("Failed to invite", "error");
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  if (hasAccess === null) {
+    return (
+      <div className="p-12 flex justify-center">
+        <span className="loading loading-spinner" />
+      </div>
+    );
+  }
+  if (!hasAccess) {
+    return <div className="p-12">You do not have access to this course.</div>;
+  }
 
   return (
     <>
@@ -351,25 +457,61 @@ export default function CourseDetails({
             </div>
           </div>
   
-          <div className="card flex flex-col rounded-lg shadow-md w-full p-6 h-fit gap-6">
-            <h2 className="text-xl font-semibold">Participants (10)</h2>
-            <div className="avatar-group -space-x-4">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="avatar">
-                  <div className="w-10 rounded-full">
-                    <img
-                      src="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
-                      alt={`Participant ${i}`}
-                    />
-                  </div>
-                </div>
-              ))}
-              <div className="avatar avatar-placeholder">
-                <div className="w-10 bg-neutral text-neutral-content">
-                  <span>+7</span>
-                </div>
-              </div>
+          {isOwner && (
+            <div className="card flex flex-col rounded-lg shadow-md w-full p-6 gap-4">
+              <h2 className="text-xl font-semibold">Invite Participant</h2>
+              <input
+                type="text"
+                className="input input-bordered w-full"
+                placeholder="User ID"
+                value={inviteId}
+                onChange={(e) => setInviteId(e.target.value)}
+              />
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleInvite}
+                disabled={inviteLoading || !inviteId.trim()}
+              >
+                {inviteLoading ? "Inviting..." : "Send Invite"}
+              </button>
             </div>
+          )}
+
+          <div className="card flex flex-col rounded-lg shadow-md w-full p-6 h-fit gap-6">
+            <h2 className="text-xl font-semibold">Participants ({participants.length})</h2>
+            {participantsLoading ? (
+              <div className="flex justify-center p-4">
+                <span className="loading loading-spinner" />
+              </div>
+            ) : (
+              <div className="avatar-group -space-x-4">
+                {participants.slice(0, 7).map((p) => (
+                  <div key={p.id} className="avatar">
+                    <div className="w-10 h-10 rounded-full overflow-hidden">
+                      {p.profilePicture ? (
+                        <img
+                          src={`${p.profilePicture}?t=${new Date().getTime()}`}
+                          alt={p.fullName}
+                          className="object-cover w-full h-full"
+                        />
+                      ) : (
+                        <div className="bg-neutral-focus text-neutral-content rounded-full w-10 h-10 flex items-center justify-center">
+                          <span className="text-sm">{getInitials(p.fullName)}</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {participants.length > 7 && (
+                  <div className="avatar placeholder">
+                    <div className="w-10 bg-neutral text-neutral-content">
+                      <span>+{participants.length - 7}</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/webserver/src/components/ui/CourseDetails.tsx
+++ b/webserver/src/components/ui/CourseDetails.tsx
@@ -5,6 +5,7 @@ import CourseDiscussion from "./CourseDiscussion";
 import { Calendar, Heart, Share2 } from "lucide-react";
 import { useNotification } from "lib/context/NotificationContext";
 import { useState, useEffect } from "react";
+import { onAuthStateChanged } from "firebase/auth";
 import { auth, db } from "lib/firebase";
 import { ref, get } from "firebase/database";
 import Modal from "./Modal";
@@ -14,7 +15,10 @@ function getInitials(name: string | undefined): string {
   if (!name) return "";
   const parts = name.trim().split(" ");
   if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
-  return parts[0].charAt(0).toUpperCase() + parts[parts.length - 1].charAt(0).toUpperCase();
+  return (
+    parts[0].charAt(0).toUpperCase() +
+    parts[parts.length - 1].charAt(0).toUpperCase()
+  );
 }
 
 export default function CourseDetails({
@@ -22,7 +26,12 @@ export default function CourseDetails({
   owner,
   imageUrl,
 }: {
-  course: { id: string; name: string; description?: string; lessons?: string[] };
+  course: {
+    id: string;
+    name: string;
+    description?: string;
+    lessons?: string[];
+  };
   owner: { displayName?: string; profilePicture?: string };
   imageUrl: string | null;
 }) {
@@ -38,11 +47,13 @@ export default function CourseDetails({
   const [isOwner, setIsOwner] = useState(false);
   const [inviteId, setInviteId] = useState("");
   const [inviteLoading, setInviteLoading] = useState(false);
-  const [participants, setParticipants] = useState<{
-    id: string;
-    fullName: string;
-    profilePicture: string;
-  }[]>([]);
+  const [participants, setParticipants] = useState<
+    {
+      id: string;
+      fullName: string;
+      profilePicture: string;
+    }[]
+  >([]);
   const [participantsLoading, setParticipantsLoading] = useState(true);
 
   const fetchParticipants = async () => {
@@ -70,13 +81,13 @@ export default function CourseDetails({
   }, [course.id]);
 
   useEffect(() => {
-    const verifyAccess = async () => {
-      const user = auth.currentUser;
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (!user) {
         setHasAccess(false);
         router.push("/courses");
         return;
       }
+
       if (user.uid === course.ownerId) {
         setHasAccess(true);
         setIsOwner(true);
@@ -84,7 +95,10 @@ export default function CourseDetails({
       }
 
       try {
-        const invitationRef = ref(db, `/courses/${course.id}/invitedUsers/${user.uid}`);
+        const invitationRef = ref(
+          db,
+          `/courses/${course.id}/invitedUsers/${user.uid}`,
+        );
         const snapshot = await get(invitationRef);
         if (snapshot.exists()) {
           setHasAccess(true);
@@ -96,9 +110,9 @@ export default function CourseDetails({
         setHasAccess(false);
         router.push("/courses");
       }
-    };
+    });
 
-    verifyAccess();
+    return () => unsubscribe();
   }, [course.id, course.ownerId, router]);
 
   useEffect(() => {
@@ -110,18 +124,18 @@ export default function CourseDetails({
           return;
         }
 
-        const response = await fetch('/api/enrollments', {
-          method: 'GET',
+        const response = await fetch("/api/enrollments", {
+          method: "GET",
           headers: {
-            'Authorization': `Bearer ${token}`
-          }
+            Authorization: `Bearer ${token}`,
+          },
         });
 
         if (response.ok) {
           const data = await response.json();
-          const isUserEnrolled = data.enrollments && 
-            data.enrollments[course.id] !== undefined;
-          
+          const isUserEnrolled =
+            data.enrollments && data.enrollments[course.id] !== undefined;
+
           setIsEnrolled(isUserEnrolled);
         }
       } catch (error) {
@@ -182,19 +196,22 @@ export default function CourseDetails({
     try {
       setIsLoading(true);
       const token = await auth.currentUser?.getIdToken();
-      
+
       if (!token) {
-        showNotification("You need to be logged in to enroll in courses", "error");
+        showNotification(
+          "You need to be logged in to enroll in courses",
+          "error",
+        );
         return;
       }
 
-      const response = await fetch('/api/enrollments', {
-        method: 'POST',
+      const response = await fetch("/api/enrollments", {
+        method: "POST",
         headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify({ courseId: course.id })
+        body: JSON.stringify({ courseId: course.id }),
       });
 
       if (response.ok) {
@@ -202,7 +219,10 @@ export default function CourseDetails({
         showNotification("Successfully enrolled in the course!", "success");
       } else {
         const error = await response.json();
-        showNotification(error.error || "Failed to enroll in the course", "error");
+        showNotification(
+          error.error || "Failed to enroll in the course",
+          "error",
+        );
       }
     } catch (error) {
       console.error("Error enrolling in course:", error);
@@ -216,19 +236,22 @@ export default function CourseDetails({
     try {
       setIsLoading(true);
       const token = await auth.currentUser?.getIdToken();
-      
+
       if (!token) {
-        showNotification("You need to be logged in to unenroll from courses", "error");
+        showNotification(
+          "You need to be logged in to unenroll from courses",
+          "error",
+        );
         return;
       }
 
-      const response = await fetch('/api/enrollments', {
-        method: 'DELETE',
+      const response = await fetch("/api/enrollments", {
+        method: "DELETE",
         headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify({ courseId: course.id })
+        body: JSON.stringify({ courseId: course.id }),
       });
 
       if (response.ok) {
@@ -236,7 +259,10 @@ export default function CourseDetails({
         showNotification("Successfully unenrolled from the course", "success");
       } else {
         const error = await response.json();
-        showNotification(error.error || "Failed to unenroll from the course", "error");
+        showNotification(
+          error.error || "Failed to unenroll from the course",
+          "error",
+        );
       }
     } catch (error) {
       console.error("Error unenrolling from course:", error);
@@ -303,10 +329,10 @@ export default function CourseDetails({
               </div>
             )}
           </div>
-  
+
           <div className="p-10">
             <h1 className="text-3xl font-bold mb-4">{course.name}</h1>
-  
+
             <div className="flex flex-row gap-2 items-center">
               <div className="avatar">
                 <div className="w-10 h-10 rounded-full overflow-hidden">
@@ -319,7 +345,9 @@ export default function CourseDetails({
                   ) : (
                     <div className="bg-neutral-focus text-neutral-content rounded-full w-10 h-10 flex items-center justify-center">
                       <span className="text-sm">
-                        {owner.displayName ? getInitials(owner.displayName) : "?"}
+                        {owner.displayName
+                          ? getInitials(owner.displayName)
+                          : "?"}
                       </span>
                     </div>
                   )}
@@ -332,24 +360,32 @@ export default function CourseDetails({
                 </div>
               </div>
             </div>
-  
-            <div className="font-semibold text-md mt-10 mb-2">About this course</div>
+
+            <div className="font-semibold text-md mt-10 mb-2">
+              About this course
+            </div>
             {course.description ? (
               <div className="prose max-w-none">
-                <p className="text-base-content/80 mb-4">{course.description}</p>
+                <p className="text-base-content/80 mb-4">
+                  {course.description}
+                </p>
               </div>
             ) : (
               <div className="italic mb-4 bg-base-200/50 rounded-lg p-4 text-base-content/70">
                 No description provided for this course.
               </div>
             )}
-  
+
             <div className="mt-10">
               <div className="flex items-center justify-between">
                 <h2 className="text-xl font-semibold mb-4 pb-2 border-b flex-grow">
                   Course Lessons
                 </h2>
-                <button onClick={() => setIsAddLessonModalOpen(true)} type="button" className="btn btn-circle btn-outline ml-4">
+                <button
+                  onClick={() => setIsAddLessonModalOpen(true)}
+                  type="button"
+                  className="btn btn-circle btn-outline ml-4"
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
@@ -362,7 +398,7 @@ export default function CourseDetails({
                   </svg>
                 </button>
               </div>
-  
+
               {course.lessons && course.lessons.length > 0 ? (
                 <ul className="space-y-3">
                   {course.lessons.map((lesson, idx) => (
@@ -390,11 +426,11 @@ export default function CourseDetails({
                 </div>
               )}
             </div>
-  
+
             <CourseDiscussion id={course.id} />
           </div>
         </div>
-  
+
         <div className="w-1/3 h-fit gap-8 flex flex-col">
           <div className="card flex flex-col rounded-lg shadow-md w-full p-6 h-fit gap-6">
             <div className="font-semibold text-lg">Registration</div>
@@ -428,7 +464,7 @@ export default function CourseDetails({
                 Join now
               </button>
             )}
-  
+
             <button
               type="button"
               className="btn btn-outline btn-secondary w-full flex items-center justify-center gap-2"
@@ -436,7 +472,7 @@ export default function CourseDetails({
               <Calendar size={18} />
               Add to Calendar
             </button>
-  
+
             <div className="flex gap-4">
               <button
                 type="button"
@@ -451,12 +487,15 @@ export default function CourseDetails({
                 onClick={() => setLiked(!liked)}
                 className="btn btn-outline btn-accent w-1/2 flex items-center justify-center gap-2"
               >
-                <Heart size={18} className={liked ? "fill-current text-red-500" : ""} />
+                <Heart
+                  size={18}
+                  className={liked ? "fill-current text-red-500" : ""}
+                />
                 {liked ? "Liked" : "Like"}
               </button>
             </div>
           </div>
-  
+
           {isOwner && (
             <div className="card flex flex-col rounded-lg shadow-md w-full p-6 gap-4">
               <h2 className="text-xl font-semibold">Invite Participant</h2>
@@ -479,7 +518,9 @@ export default function CourseDetails({
           )}
 
           <div className="card flex flex-col rounded-lg shadow-md w-full p-6 h-fit gap-6">
-            <h2 className="text-xl font-semibold">Participants ({participants.length})</h2>
+            <h2 className="text-xl font-semibold">
+              Participants ({participants.length})
+            </h2>
             {participantsLoading ? (
               <div className="flex justify-center p-4">
                 <span className="loading loading-spinner" />
@@ -497,7 +538,9 @@ export default function CourseDetails({
                         />
                       ) : (
                         <div className="bg-neutral-focus text-neutral-content rounded-full w-10 h-10 flex items-center justify-center">
-                          <span className="text-sm">{getInitials(p.fullName)}</span>
+                          <span className="text-sm">
+                            {getInitials(p.fullName)}
+                          </span>
                         </div>
                       )}
                     </div>
@@ -515,7 +558,7 @@ export default function CourseDetails({
           </div>
         </div>
       </div>
-  
+
       <Modal
         isOpen={isAddLessonModalOpen}
         onClose={() => setIsAddLessonModalOpen(false)}
@@ -523,7 +566,9 @@ export default function CourseDetails({
       >
         <div className="p-4 space-y-4">
           <label className="block">
-            <span className="text-md font-medium text-base-content">Lesson Name</span>
+            <span className="text-md font-medium text-base-content">
+              Lesson Name
+            </span>
             <input
               type="text"
               value={newLessonName}
@@ -540,12 +585,16 @@ export default function CourseDetails({
             >
               Cancel
             </button>
-            <button type="button" className="btn btn-primary" onClick={handleAddLesson}>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleAddLesson}
+            >
               Add Lesson
             </button>
           </div>
         </div>
       </Modal>
     </>
-  );  
+  );
 }

--- a/webserver/src/components/ui/CourseDetails.tsx
+++ b/webserver/src/components/ui/CourseDetails.tsx
@@ -28,6 +28,7 @@ export default function CourseDetails({
 }: {
   course: {
     id: string;
+    ownerId: string;
     name: string;
     description?: string;
     lessons?: string[];

--- a/webserver/src/components/ui/CourseDetails.tsx
+++ b/webserver/src/components/ui/CourseDetails.tsx
@@ -32,6 +32,9 @@ export default function CourseDetails({
     name: string;
     description?: string;
     lessons?: string[];
+    scheduledDate?: string;
+    recurrence?: "once" | "weekly";
+    access?: "open" | "invite";
   };
   owner: { displayName?: string; profilePicture?: string };
   imageUrl: string | null;
@@ -46,7 +49,13 @@ export default function CourseDetails({
   const [isCheckingEnrollment, setIsCheckingEnrollment] = useState(true);
   const [hasAccess, setHasAccess] = useState<boolean | null>(null);
   const [isOwner, setIsOwner] = useState(false);
-  const [inviteId, setInviteId] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [emailOptions, setEmailOptions] = useState<{
+    id: string;
+    email?: string | null;
+    name?: string | null;
+  }[]>([]);
+  const [inviteUserId, setInviteUserId] = useState("");
   const [inviteLoading, setInviteLoading] = useState(false);
   const [participants, setParticipants] = useState<
     {
@@ -82,6 +91,29 @@ export default function CourseDetails({
   }, [course.id]);
 
   useEffect(() => {
+    const loadSuggestions = async () => {
+      if (!inviteEmail.trim()) {
+        setEmailOptions([]);
+        return;
+      }
+      try {
+        const token = await auth.currentUser?.getIdToken();
+        const res = await fetch(`/api/users?search=${encodeURIComponent(inviteEmail)}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setEmailOptions(data.users || []);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    const handler = setTimeout(loadSuggestions, 300);
+    return () => clearTimeout(handler);
+  }, [inviteEmail]);
+
+  useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (!user) {
         setHasAccess(false);
@@ -101,15 +133,15 @@ export default function CourseDetails({
           `/courses/${course.id}/invitedUsers/${user.uid}`,
         );
         const snapshot = await get(invitationRef);
-        if (snapshot.exists()) {
+        if (snapshot.exists() || course.access === "open") {
           setHasAccess(true);
         } else {
           setHasAccess(false);
           router.push("/courses");
         }
       } catch {
-        setHasAccess(false);
-        router.push("/courses");
+        setHasAccess(course.access === "open");
+        if (course.access !== "open") router.push("/courses");
       }
     });
 
@@ -156,6 +188,34 @@ export default function CourseDetails({
     } catch {
       showNotification("Failed to copy link", "error");
     }
+  };
+
+  const handleAddToCalendar = () => {
+    if (!course.scheduledDate) return;
+    const start = new Date(course.scheduledDate);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const toICSDate = (d: Date) =>
+      d.toISOString().replace(/[-:]|\.\d{3}/g, "").slice(0, 15) + "Z";
+
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VEVENT",
+      `DTSTART:${toICSDate(start)}`,
+      `DTEND:${toICSDate(end)}`,
+      `SUMMARY:${course.name}`,
+      `URL:${window.location.href}`,
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\n");
+
+    const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${course.name}.ics`;
+    link.click();
+    URL.revokeObjectURL(url);
   };
 
   const handleAddLesson = async () => {
@@ -274,7 +334,7 @@ export default function CourseDetails({
   };
 
   const handleInvite = async () => {
-    if (!inviteId.trim()) return;
+    if (!inviteUserId) return;
     try {
       setInviteLoading(true);
       const token = await auth.currentUser?.getIdToken();
@@ -284,11 +344,12 @@ export default function CourseDetails({
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ userId: inviteId.trim() }),
+        body: JSON.stringify({ userId: inviteUserId }),
       });
       if (response.ok) {
         showNotification("User invited", "success");
-        setInviteId("");
+        setInviteEmail("");
+        setInviteUserId("");
         fetchParticipants();
       } else {
         const err = await response.json();
@@ -435,7 +496,7 @@ export default function CourseDetails({
         <div className="w-1/3 h-fit gap-8 flex flex-col">
           <div className="card flex flex-col rounded-lg shadow-md w-full p-6 h-fit gap-6">
             <div className="font-semibold text-lg">Registration</div>
-            {isCheckingEnrollment ? (
+            {isOwner ? null : isCheckingEnrollment ? (
               <button type="button" className="btn btn-primary w-full" disabled>
                 <span className="loading loading-spinner loading-sm"></span>
                 Checking enrollment...
@@ -469,6 +530,7 @@ export default function CourseDetails({
             <button
               type="button"
               className="btn btn-outline btn-secondary w-full flex items-center justify-center gap-2"
+              onClick={handleAddToCalendar}
             >
               <Calendar size={18} />
               Add to Calendar
@@ -503,18 +565,63 @@ export default function CourseDetails({
               <input
                 type="text"
                 className="input input-bordered w-full"
-                placeholder="User ID"
-                value={inviteId}
-                onChange={(e) => setInviteId(e.target.value)}
+                placeholder="Search email"
+                value={inviteEmail}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setInviteEmail(val);
+                  const match = emailOptions.find(
+                    (o) => o.email === val || o.name === val
+                  );
+                  setInviteUserId(match ? match.id : "");
+                }}
+                list="email-suggestions"
               />
+              <datalist id="email-suggestions">
+                {emailOptions.map((opt) => (
+                  <option key={opt.id} value={opt.email || opt.name || ""} />
+                ))}
+              </datalist>
               <button
                 type="button"
                 className="btn btn-primary"
                 onClick={handleInvite}
-                disabled={inviteLoading || !inviteId.trim()}
+                disabled={inviteLoading || !inviteUserId}
               >
                 {inviteLoading ? "Inviting..." : "Send Invite"}
               </button>
+            </div>
+          )}
+
+          {isOwner && (
+            <div className="card flex flex-col rounded-lg shadow-md w-full p-6 gap-4">
+              <h2 className="text-xl font-semibold">Course Access</h2>
+              <select
+                className="select select-bordered w-full"
+                value={course.access || 'open'}
+                onChange={async (e) => {
+                  const val = e.target.value;
+                  try {
+                    const token = await auth.currentUser?.getIdToken();
+                    await fetch(`/api/courses/${course.id}`, {
+                      method: 'PATCH',
+                      headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${token}`,
+                      },
+                      body: JSON.stringify({ access: val }),
+                    });
+                    course.access = val as 'open' | 'invite';
+                    showNotification('Course updated', 'success');
+                  } catch (err) {
+                    console.error(err);
+                    showNotification('Failed to update', 'error');
+                  }
+                }}
+              >
+                <option value="open">Open</option>
+                <option value="invite">Invite Only</option>
+              </select>
             </div>
           )}
 

--- a/webserver/src/components/ui/CreateCourseForm.tsx
+++ b/webserver/src/components/ui/CreateCourseForm.tsx
@@ -14,6 +14,7 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [startDate, setStartDate] = useState("");
   const [recurrence, setRecurrence] = useState("once");
+  const [access, setAccess] = useState("open");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -81,6 +82,7 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
       formData.append('description', description);
       formData.append('startDate', startDate);
       formData.append('recurrence', recurrence);
+      formData.append('access', access);
       if (image) {
         formData.append('image', image);
       }
@@ -210,6 +212,20 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
           >
             <option value="once">One Time</option>
             <option value="weekly">Weekly</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">
+          Access
+          <select
+            className="select select-bordered w-full mt-1"
+            value={access}
+            onChange={(e) => setAccess(e.target.value)}
+          >
+            <option value="open">Open</option>
+            <option value="invite">Invite Only</option>
           </select>
         </label>
       </div>

--- a/webserver/src/components/ui/CreateCourseForm.tsx
+++ b/webserver/src/components/ui/CreateCourseForm.tsx
@@ -12,9 +12,12 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
   const [description, setDescription] = useState('');
   const [image, setImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [startDate, setStartDate] = useState("");
+  const [recurrence, setRecurrence] = useState("once");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const minDate = new Date().toISOString().slice(0, 16);
   
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -57,6 +60,16 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
       return;
     }
     
+    if (!startDate) {
+      setError('Start date and time is required');
+      return;
+    }
+    const chosenDate = new Date(startDate);
+    if (isNaN(chosenDate.getTime()) || chosenDate <= new Date()) {
+      setError('Start date must be in the future');
+      return;
+    }
+
     setIsSubmitting(true);
     setError(null);
     
@@ -66,6 +79,8 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
       const formData = new FormData();
       formData.append('name', name);
       formData.append('description', description);
+      formData.append('startDate', startDate);
+      formData.append('recurrence', recurrence);
       if (image) {
         formData.append('image', image);
       }
@@ -168,6 +183,34 @@ export default function CreateCourseForm({ onClose, onSuccess }: CreateCourseFor
             rows={4}
             className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium floating-label">
+          <span>Start Date &amp; Time</span>
+          <input
+            type="datetime-local"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            required
+            min={minDate}
+          />
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">
+          Occurrence
+          <select
+            className="select select-bordered w-full mt-1"
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+          >
+            <option value="once">One Time</option>
+            <option value="weekly">Weekly</option>
+          </select>
         </label>
       </div>
       


### PR DESCRIPTION
## Summary
- reintroduce invite system with API routes and notification badge
- add course schedule support with start date and recurrence
- update calendar to read events from course schedule
- restrict course access to invitees and owner

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084c39a8883288f25c2f5325e43c2